### PR TITLE
Add React to peer dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,8 @@
 		"strip-ansi": "^7.1.2"
 	},
 	"peerDependencies": {
-		"ink": ">=6"
+		"ink": ">=6",
+		"react": ">=19.2.0"
 	},
 	"devDependencies": {
 		"@sindresorhus/tsconfig": "^8.1.0",


### PR DESCRIPTION
This package imports from `react` at runtime, but `react` is currently only listed in `devDependencies`.

With strict package managers such as pnpm, consumers can hit a runtime module resolution error when `ink-gradient` is installed as a transitive dependency:

```text
Error [ERR_MODULE_NOT_FOUND]: Cannot find package 'react' imported from .../ink-gradient/dist/index.js
```

This adds `react` to `peerDependencies`, matching the runtime import and Ink's own peer dependency requirement.

Verified with:

```sh
pnpm test
```

I also verified the consumer failure case locally by installing `@vegamo/deepcode-cli` in a temporary pnpm project and applying the same dependency metadata via `packageExtensions`. With `react` included in `ink-gradient`'s peer dependency context, `pnpm exec deepcode --help` runs successfully.